### PR TITLE
Updated loading of server environment variables

### DIFF
--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -180,6 +180,7 @@ abstract class ValetDriver
 
     /**
      * Load server environment variables if available.
+     * Processes any '*' entries first, and then adds site-specific entries
      *
      * @param  string  $sitePath
      * @param  string  $siteName
@@ -193,12 +194,19 @@ abstract class ValetDriver
         }
 
         $variables = include $varFilePath;
-        if (! isset($variables[$siteName])) {
-            return;
+
+        $variablesToSet = isset($variables['*']) ? $variables['*'] : [];
+
+        if (isset($variables[$siteName])) {
+            $variablesToSet = array_merge($variablesToSet, $variables[$siteName]);
         }
 
-        foreach ($variables[$siteName] as $key => $value) {
+        foreach ($variablesToSet as $key => $value) {
+            if (! is_string($key)) continue;
             $_SERVER[$key] = $value;
+            $_ENV[$key] = $value;
+            putenv($key . '=' . $value);
         }
     }
+
 }


### PR DESCRIPTION
- added `putenv()` for Laravel compatibility
- added `$_ENV` for generic compatibility
- added wildcard processing, so site array named `*` gets processed always (if present), and then site-specific entries are added and will override the wildcard.

Sample `.valet-env.php`:
```php
<?php

return [
    '*' => [
        'USER' => 'vagrant',
    ],
    'demo' => [
        'MY_CUSTOM_VAR' => 'special_value',
        'USER' => 'travis',
    ],
];
```
(Note: order of entries in the array is irrelevant, as the parser reads `*` first, followed by site-specific entries.)